### PR TITLE
Crash fix when conversion from string to fname 

### DIFF
--- a/Source/ProjectCleaner/Private/Core/ProjectCleanerDataManager.cpp
+++ b/Source/ProjectCleaner/Private/Core/ProjectCleanerDataManager.cpp
@@ -574,22 +574,22 @@ void FProjectCleanerDataManager::FindIndirectAssets()
 		FRegexMatcher Matcher(Pattern, FileContent);
 		while (Matcher.FindNext())
 		{
-			FName FoundedAssetObjectPath =  FName{Matcher.GetCaptureGroup(0)};
-			if (!FoundedAssetObjectPath.IsValid()) continue;
+			FString FoundedAssetObjectPath =  Matcher.GetCaptureGroup(0);
+		
 
 			// if ObjectPath ends with "_C" , then its probably blueprint, so we trim that
-			if (FoundedAssetObjectPath.ToString().EndsWith("_C"))
+			if (FoundedAssetObjectPath.EndsWith("_C"))
 			{
-				FString TrimmedObjectPath = FoundedAssetObjectPath.ToString();
+				FString TrimmedObjectPath = FoundedAssetObjectPath;
 				TrimmedObjectPath.RemoveFromEnd("_C");
 				
-				FoundedAssetObjectPath = FName{*TrimmedObjectPath};
+				FoundedAssetObjectPath = TrimmedObjectPath;
 			}
 			const FAssetData* AssetData = AllAssets.FindByPredicate([&] (const FAssetData& Elem)
 			{
 				return
-					Elem.ObjectPath.IsEqual(FoundedAssetObjectPath) ||
-					Elem.PackageName.IsEqual(FoundedAssetObjectPath);
+					Elem.ObjectPath.ToString()==(FoundedAssetObjectPath) ||
+					Elem.PackageName.ToString()==(FoundedAssetObjectPath);
 			});
 
 			if (!AssetData) continue;
@@ -600,7 +600,7 @@ void FProjectCleanerDataManager::FindIndirectAssets()
 			for (int32 i = 0; i < Lines.Num(); ++i)
 			{
 				if (!Lines.IsValidIndex(i)) continue;
-				if (!Lines[i].Contains(FoundedAssetObjectPath.ToString())) continue;
+				if (!Lines[i].Contains(FoundedAssetObjectPath)) continue;
 			
 				FIndirectAsset IndirectAsset;
 				IndirectAsset.File = FPaths::ConvertRelativePathToFull(File);
@@ -611,6 +611,7 @@ void FProjectCleanerDataManager::FindIndirectAssets()
 		}
 	}
 }
+
 
 void FProjectCleanerDataManager::FindEmptyFolders(const bool bScanDevelopersContent)
 {


### PR DESCRIPTION
plugin will crash if converting from string to name is bigger than FName limit ( in our case it was ) .conversion from FName to FString is safer . 