### PR TITLE
Fix Asset Reference Regex Pattern

### DIFF
--- a/Source/ProjectCleaner/Private/Core/ProjectCleanerDataManager.cpp
+++ b/Source/ProjectCleaner/Private/Core/ProjectCleanerDataManager.cpp
@@ -570,7 +570,7 @@ void FProjectCleanerDataManager::FindIndirectAssets()
 		
 		if (!ProjectCleanerUtility::HasIndirectlyUsedAssets(FileContent)) continue;
 
-		static FRegexPattern Pattern(TEXT(R"(\/Game(.*)\b)"));
+		static FRegexPattern Pattern(TEXT(R"(\/Game([A-Za-z0-9_.\/]+)\b)"));
 		FRegexMatcher Matcher(Pattern, FileContent);
 		while (Matcher.FindNext())
 		{


### PR DESCRIPTION
Hi,
Here is a small change to the the `Pattern` regex used to match asset reference name from `FProjectCleanerDataManager::FindIndirectAssets()`.
Sometimes it was not matching the pattern correctly.

Here is an example of matching failure:
![FIxRegexProjectCleaner](https://user-images.githubusercontent.com/92514278/140497064-bf22e1a9-90f2-4660-928a-d59fa33e7647.png)
