### PR TITLE
Support Mac

### DIFF
--- a/ProjectCleaner.uplugin
+++ b/ProjectCleaner.uplugin
@@ -22,7 +22,8 @@
 			"LoadingPhase": "PostDefault",
 			"WhitelistPlatforms": [
 				"Win64",
-				"Linux"
+				"Linux",
+                                "Mac"
 			]
 		}
 	],


### PR DESCRIPTION
Tested by compiling on Mac M1 with Rider

We can start with 5.4 :)

I will test again 5.3 and possibly 5.2 soon!